### PR TITLE
New configuration features and handling a corner case for interrupted rerolling process

### DIFF
--- a/Enhanced_Quests_Local/Assets/manifest.json
+++ b/Enhanced_Quests_Local/Assets/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Enhanced Quests Local",
-  "author": "CrossTM",
-  "version": "1.1.0",
+  "author": "Shokram - CrossTM - Watashinoushi",
+  "version": "1.1.1",
   "description": "",
   "nexus_id": "",
   "donate_url": "",

--- a/Enhanced_Quests_Local/Assets/manifest.json
+++ b/Enhanced_Quests_Local/Assets/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Enhanced Quests Local",
-  "author": "Shokram - CrossTM - Watashinoushi",
-  "version": "1.1.1",
+  "author": "CrossTM",
+  "version": "1.2.0",
   "description": "",
   "nexus_id": "",
   "donate_url": "",

--- a/Enhanced_Quests_Local/Enhanced_Quests_Local.cs
+++ b/Enhanced_Quests_Local/Enhanced_Quests_Local.cs
@@ -56,6 +56,9 @@ public class Enhanced_Quests : MonoBehaviour
     private int dailiesRerolled;
     private int weekliesRerolled;
 
+    private int softRerollCap = 20;
+    private int hardRerollCap = 25;
+
     public void Awake()
     {
         Instance = this;
@@ -335,9 +338,9 @@ public class Enhanced_Quests : MonoBehaviour
         {
             //Quick Quests
             case QuestType.CompleteDailyQuests:
-            case QuestType.HitRandomSilverBoxes:
             case QuestType.PickUpCoins:
             case QuestType.PickUpGemstones:
+            case QuestType.Boost:
                 return true;
 
             //Chest Hunt Daily vs Weekly and if relevant quest is completed
@@ -351,11 +354,12 @@ public class Enhanced_Quests : MonoBehaviour
             case QuestType.KillEnemiesWithRageMode:
                 {
                     var questTypeName = quest.GetIl2CppType().FullName;
-                    if (questTypeName == "DailyQuest") return true; else return false;
+                    if (questTypeName == "DailyQuest") return (dailiesRerolled > hardRerollCap); else return false;
                 }
 
             //Conditional Quests
             case QuestType.GetMaterials:
+                return false;
             case QuestType.KillEnemies:
             case QuestType.KillGiants:
                 return ConditionalQuestCheck(quest);
@@ -363,13 +367,14 @@ public class Enhanced_Quests : MonoBehaviour
             //Medium Quests
             case QuestType.BonusStage:
             case QuestType.BonusStageSections:
-            case QuestType.Boost:
-                return (dailiesRerolled > 15);
+            case QuestType.CompleteAscendingHeights:
+                return (dailiesRerolled > softRerollCap);
 
             //Long Quests
             case QuestType.HitRandomBoxes:
+            case QuestType.HitRandomSilverBoxes:
             case QuestType.UseRageMode:
-                return (dailiesRerolled > 20);
+                return (dailiesRerolled > hardRerollCap);
 
             //Manual Quest
             case QuestType.CraftTemporaryItems:
@@ -378,6 +383,7 @@ public class Enhanced_Quests : MonoBehaviour
                 return false;
 
             default:
+                Plugin.Logger.Warning($"Unhandled QuestType: {questType} - {quest.name}");   
                 return true; // Default case for unhandled quest types
         }
     }
@@ -442,7 +448,7 @@ public class Enhanced_Quests : MonoBehaviour
         {
             var dq = new DailyQuest(quest.Pointer);
 
-//            Plugin.Logger.Msg($"Rerolling Daily Quest: {dq.questType} - {dq.name}");
+            Plugin.Logger.Msg($"Rerolling Daily Quest: {dq.questType} - {dq.name}");
 
             _dailyQuestReroll.PrepareReroll(dq);
             yield return new WaitForSeconds(0.01f);

--- a/Enhanced_Quests_Local/Enhanced_Quests_Local.cs
+++ b/Enhanced_Quests_Local/Enhanced_Quests_Local.cs
@@ -334,7 +334,7 @@ public class Enhanced_Quests : MonoBehaviour
     {
         QuestType questType = quest.questType;
 
-        if(!Plugin.Settings.EnableAutoReroll.Value) return true;
+        if (!Plugin.Settings.ResetReroll.Value || !Plugin.Settings.EnableAutoReroll.Value) return true;
 
         switch (questType)
         {

--- a/Enhanced_Quests_Local/Enhanced_Quests_Local.cs
+++ b/Enhanced_Quests_Local/Enhanced_Quests_Local.cs
@@ -56,8 +56,8 @@ public class Enhanced_Quests : MonoBehaviour
     private int dailiesRerolled;
     private int weekliesRerolled;
 
-    private int softRerollCap = 20;
-    private int hardRerollCap = 25;
+    private int softRerollCap = 15;
+    private int hardRerollCap = 20;
 
     public void Awake()
     {
@@ -334,6 +334,8 @@ public class Enhanced_Quests : MonoBehaviour
     {
         QuestType questType = quest.questType;
 
+        if(!Plugin.Settings.EnableAutoReroll.Value) return true;
+
         switch (questType)
         {
             //Quick Quests
@@ -359,7 +361,7 @@ public class Enhanced_Quests : MonoBehaviour
 
             //Conditional Quests
             case QuestType.GetMaterials:
-                return false;
+                return !Plugin.Settings.AutoRerollGetMaterials.Value;
             case QuestType.KillEnemies:
             case QuestType.KillGiants:
                 return ConditionalQuestCheck(quest);
@@ -372,7 +374,9 @@ public class Enhanced_Quests : MonoBehaviour
 
             //Long Quests
             case QuestType.HitRandomBoxes:
+                return !Plugin.Settings.AutoRerollHitRandomBox.Value || (dailiesRerolled > hardRerollCap);
             case QuestType.HitRandomSilverBoxes:
+                return !Plugin.Settings.AutoRerollHitSilverBox.Value || (dailiesRerolled > hardRerollCap);
             case QuestType.UseRageMode:
                 return (dailiesRerolled > hardRerollCap);
 

--- a/Enhanced_Quests_Local/Enhanced_Quests_Local.sln
+++ b/Enhanced_Quests_Local/Enhanced_Quests_Local.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36511.14 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Enhanced_Quests_Local", "Enhanced_Quests_Local.csproj", "{DF40958D-44F0-C2BE-91B4-60EED9165F05}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DF40958D-44F0-C2BE-91B4-60EED9165F05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF40958D-44F0-C2BE-91B4-60EED9165F05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF40958D-44F0-C2BE-91B4-60EED9165F05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF40958D-44F0-C2BE-91B4-60EED9165F05}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BA38947C-4866-4DAB-A1AD-6C11DDCA415F}
+	EndGlobalSection
+EndGlobal

--- a/Enhanced_Quests_Local/MyPluginInfo.cs
+++ b/Enhanced_Quests_Local/MyPluginInfo.cs
@@ -4,6 +4,6 @@ public static class MyPluginInfo
 {
     public const string PLUGIN_GUID = "Enhanced_Quests_Local";
     public const string PLUGIN_NAME = "Enhanced_Quests_Local";
-    public const string PLUGIN_VERSION = "1.1.1";
-    public const string PLUGIN_AUTHOR = "Shokram - CrossTM - Watashinoushi";
+    public const string PLUGIN_VERSION = "1.2.0";
+    public const string PLUGIN_AUTHOR = "Shokram";
 }

--- a/Enhanced_Quests_Local/MyPluginInfo.cs
+++ b/Enhanced_Quests_Local/MyPluginInfo.cs
@@ -4,6 +4,6 @@ public static class MyPluginInfo
 {
     public const string PLUGIN_GUID = "Enhanced_Quests";
     public const string PLUGIN_NAME = "Enhanced_Quests";
-    public const string PLUGIN_VERSION = "1.1.0";
-    public const string PLUGIN_AUTHOR = "Shokram";
+    public const string PLUGIN_VERSION = "1.1.1";
+    public const string PLUGIN_AUTHOR = "Shokram - CrossTM - Watashinoushi";
 }

--- a/Enhanced_Quests_Local/MyPluginInfo.cs
+++ b/Enhanced_Quests_Local/MyPluginInfo.cs
@@ -2,8 +2,8 @@ namespace Enhanced_Quests_Local;
 
 public static class MyPluginInfo
 {
-    public const string PLUGIN_GUID = "Enhanced_Quests";
-    public const string PLUGIN_NAME = "Enhanced_Quests";
+    public const string PLUGIN_GUID = "Enhanced_Quests_Local";
+    public const string PLUGIN_NAME = "Enhanced_Quests_Local";
     public const string PLUGIN_VERSION = "1.1.1";
     public const string PLUGIN_AUTHOR = "Shokram - CrossTM - Watashinoushi";
 }

--- a/Enhanced_Quests_Local/Settings.cs
+++ b/Enhanced_Quests_Local/Settings.cs
@@ -13,6 +13,9 @@ internal sealed class Settings(string configName) : BaseConfig(configName)
     internal MelonPreferences_Entry<bool> AutoRerollGetMaterials;
     internal MelonPreferences_Entry<bool> AutoRerollHitSilverBox;
     internal MelonPreferences_Entry<bool> AutoRerollHitRandomBox;
+    internal MelonPreferences_Entry<int> SoftRerollCap;
+    internal MelonPreferences_Entry<int> HardRerollCap;
+    internal MelonPreferences_Entry<int> RerollCheckMinutes;
 
     protected override void SetBindings()
     {
@@ -32,6 +35,11 @@ internal sealed class Settings(string configName) : BaseConfig(configName)
             "Toggle Automatic Reroll of Hit Silver Boxes Quests");
         AutoRerollHitRandomBox = Bind("AutoRerollHitRandomBox", false,
             "Toggle Automatic Reroll of Hit Random Boxes Quests");
-
+        SoftRerollCap = Bind("SoftRerollCap", 15,
+            "Soft reroll cap for medium quests (minimum: 15)");
+        HardRerollCap = Bind("HardRerollCap", 20,
+            "Hard reroll cap for long quests (minimum: 20)");
+        RerollCheckMinutes = Bind("RerollCheckMinutes", 5,
+            "Minutes between forced reroll checks (minimum: 5)");
     }
 }

--- a/Enhanced_Quests_Local/Settings.cs
+++ b/Enhanced_Quests_Local/Settings.cs
@@ -9,6 +9,11 @@ internal sealed class Settings(string configName) : BaseConfig(configName)
     internal MelonPreferences_Entry<bool> ResetWeeklies;
     internal MelonPreferences_Entry<bool> ResetPortal;
     internal MelonPreferences_Entry<bool> ResetReroll;
+    internal MelonPreferences_Entry<bool> EnableAutoReroll;
+    internal MelonPreferences_Entry<bool> AutoRerollGetMaterials;
+    internal MelonPreferences_Entry<bool> AutoRerollHitSilverBox;
+    internal MelonPreferences_Entry<bool> AutoRerollHitRandomBox;
+    internal MelonPreferences_Entry<bool> AutoRerollWindDashKills;
 
 
     protected override void SetBindings()
@@ -20,6 +25,17 @@ internal sealed class Settings(string configName) : BaseConfig(configName)
         ResetPortal = Bind("ResetPortal", false,
             "Toggle Reset Portal");
         ResetReroll = Bind("ResetReroll", false,
-                "Toggle Reset Quest Reroll");
+            "Toggle Reset Quest Reroll");
+        EnableAutoReroll = Bind("EnableAutoReroll", false,
+            "Enable Automatic Quest Reroll Functionality");
+        AutoRerollGetMaterials = Bind("AutoRerollGetMaterials", true,
+            "Toggle Automatic Reroll of Get Materials Quests");
+        AutoRerollWindDashKills = Bind("AutoRerollWindDashKills", true,
+            "Toggle Automatic Reroll Wind Dash Kills");
+        AutoRerollHitSilverBox = Bind("AutoRerollHitSilverBox", false,
+            "Toggle Automatic Reroll of Hit Silver Boxes Quests");
+        AutoRerollHitRandomBox = Bind("AutoRerollHitRandomBox", false,
+            "Toggle Automatic Reroll of Hit Random Boxes Quests");
+
     }
 }

--- a/Enhanced_Quests_Local/Settings.cs
+++ b/Enhanced_Quests_Local/Settings.cs
@@ -15,6 +15,7 @@ internal sealed class Settings(string configName) : BaseConfig(configName)
     internal MelonPreferences_Entry<bool> AutoRerollHitRandomBox;
     internal MelonPreferences_Entry<int> SoftRerollCap;
     internal MelonPreferences_Entry<int> HardRerollCap;
+    internal MelonPreferences_Entry<bool> EnableForceRerollTimer;
     internal MelonPreferences_Entry<int> RerollCheckMinutes;
 
     protected override void SetBindings()
@@ -39,6 +40,8 @@ internal sealed class Settings(string configName) : BaseConfig(configName)
             "Soft reroll cap for medium quests (minimum: 15)");
         HardRerollCap = Bind("HardRerollCap", 20,
             "Hard reroll cap for long quests (minimum: 20)");
+        EnableForceRerollTimer = Bind("EnableForceRerollTimer", false,
+            "Toggle forced rerolls every X amount of minutes");
         RerollCheckMinutes = Bind("RerollCheckMinutes", 5,
             "Minutes between forced reroll checks (minimum: 5)");
     }

--- a/Enhanced_Quests_Local/Settings.cs
+++ b/Enhanced_Quests_Local/Settings.cs
@@ -13,8 +13,6 @@ internal sealed class Settings(string configName) : BaseConfig(configName)
     internal MelonPreferences_Entry<bool> AutoRerollGetMaterials;
     internal MelonPreferences_Entry<bool> AutoRerollHitSilverBox;
     internal MelonPreferences_Entry<bool> AutoRerollHitRandomBox;
-    internal MelonPreferences_Entry<bool> AutoRerollWindDashKills;
-
 
     protected override void SetBindings()
     {
@@ -26,13 +24,11 @@ internal sealed class Settings(string configName) : BaseConfig(configName)
             "Toggle Reset Portal");
         ResetReroll = Bind("ResetReroll", false,
             "Toggle Reset Quest Reroll");
-        EnableAutoReroll = Bind("EnableAutoReroll", false,
+        EnableAutoReroll = Bind("EnableAutoReroll", true,
             "Enable Automatic Quest Reroll Functionality");
         AutoRerollGetMaterials = Bind("AutoRerollGetMaterials", true,
             "Toggle Automatic Reroll of Get Materials Quests");
-        AutoRerollWindDashKills = Bind("AutoRerollWindDashKills", true,
-            "Toggle Automatic Reroll Wind Dash Kills");
-        AutoRerollHitSilverBox = Bind("AutoRerollHitSilverBox", false,
+        AutoRerollHitSilverBox = Bind("AutoRerollHitSilverBox", true,
             "Toggle Automatic Reroll of Hit Silver Boxes Quests");
         AutoRerollHitRandomBox = Bind("AutoRerollHitRandomBox", false,
             "Toggle Automatic Reroll of Hit Random Boxes Quests");


### PR DESCRIPTION
Added settings to force reroll of:
- Material Quests (in case you material stock is full and not uncapped)
- Silver Random Boxes (in case you have the dark divinity enabled to disable silver boxes or you don't have the silver death dark divinity enabled)
- Random Boxes (in case you have silver boxes enabled)

A global setting to disable auto rerolling

Settings to set the "soft cap" of rerolling attempts for medium duration quests and "hard cap" for attempts on long duration quests

A timer for a forced reroll every X minutes (5 by default) to handle a corner case when, for example, a chest hunt is triggered while the rerolling process is running. This interruption could potentially cause impossible to complete quests to remain active (maybe there's a better solution to handle this, like an event that is triggered when the minigames are finalized)

Handling Ascending Heights quests as they were not being contemplated